### PR TITLE
Modernise specs

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,1 +1,2 @@
 --colour
+--require spec_helper

--- a/TODO
+++ b/TODO
@@ -1,1 +1,0 @@
-* support parslet > 1.4.0

--- a/lib/upmark/transform/markdown.rb
+++ b/lib/upmark/transform/markdown.rb
@@ -7,6 +7,33 @@ module Upmark
 
       rule(text: simple(:value)) { value.to_s }
 
+      # Pass all unmatched elements through.
+      rule(
+        element: {
+          name:       simple(:name),
+          attributes: subtree(:attributes),
+          children:   sequence(:children),
+          ignore:     simple(:ignore)
+        }
+      ) do |element|
+        attributes = map_attributes_subtree(element[:attributes])
+        children   = element[:children].join
+        name       = element[:name]
+
+        attributes_list =
+          if attributes.any?
+            " " + attributes.map {|name, value| %Q{#{name}="#{value}"} }.join(" ")
+          else
+            ""
+          end
+
+        if children.empty?
+          %Q{<#{name}#{attributes_list} />}
+        else
+          %Q{<#{name}#{attributes_list}>#{children}</#{name}>}
+        end
+      end
+
       def self.text(element)
         element[:children].join.gsub(/(\n)+/, '\1')
       end
@@ -52,32 +79,6 @@ module Upmark
 
       element(:br) { "\n" }
 
-      # Pass all unmatched elements through.
-      rule(
-        element: {
-          name:       simple(:name),
-          attributes: subtree(:attributes),
-          children:   sequence(:children),
-          ignore:     simple(:ignore)
-        }
-      ) do |element|
-        attributes = map_attributes_subtree(element[:attributes])
-        children   = element[:children].join
-        name       = element[:name]
-
-        attributes_list =
-          if attributes.any?
-            " " + attributes.map {|name, value| %Q{#{name}="#{value}"} }.join(" ")
-          else
-            ""
-          end
-
-        if children.empty?
-          %Q{<#{name}#{attributes_list} />}
-        else
-          %Q{<#{name}#{attributes_list}>#{children}</#{name}>}
-        end
-      end
     end
   end
 end

--- a/spec/acceptance/upmark_spec.rb
+++ b/spec/acceptance/upmark_spec.rb
@@ -1,4 +1,4 @@
-describe Upmark, ".convert" do
+RSpec.describe Upmark, ".convert" do
   subject { Upmark.convert(html) }
 
   context "<a>" do

--- a/spec/acceptance/upmark_spec.rb
+++ b/spec/acceptance/upmark_spec.rb
@@ -1,39 +1,46 @@
 RSpec.describe Upmark, ".convert" do
-  subject { Upmark.convert(html) }
+  RSpec::Matchers.define :convert_to do |expected|
+    match do |html|
+      Upmark.convert(actual) == expected
+    end
+  end
 
   context "<a>" do
-    let(:html) { <<-HTML.strip }
-<p><a href="http://helvetica.com/" title="art party organic">messenger <strong>bag</strong> skateboard</a></p>
-    HTML
-
-    it { should == <<-MD.strip }
-[messenger **bag** skateboard](http://helvetica.com/ "art party organic")
-    MD
+    specify 'converts to []()' do
+      expect(<<-HTML.strip
+        <p><a href="http://helvetica.com/" title="art party organic">messenger <strong>bag</strong> skateboard</a></p>
+      HTML
+      ).to convert_to <<-MD.strip
+        [messenger **bag** skateboard](http://helvetica.com/ "art party organic")
+      MD
+    end
   end
 
   context "<a> hard" do
-    let(:html) { <<-HTML.strip }
-<p><a href="http://jobs.latrobe.edu.au/jobDetails.asp?sJobIDs=545808&amp;sKeywords=business">Manager, Business Solutions</a></p>
-    HTML
-
-    it { should == <<-MD.strip }
+    specify 'converts as []()' do
+      expect(<<-HTML.strip
+        <p><a href="http://jobs.latrobe.edu.au/jobDetails.asp?sJobIDs=545808&amp;sKeywords=business">Manager, Business Solutions</a></p>
+      HTML
+      ).to convert_to <<-MD.strip
 [Manager, Business Solutions](http://jobs.latrobe.edu.au/jobDetails.asp?sJobIDs=545808&amp;sKeywords=business "")
-    MD
+      MD
+    end
   end
 
   context "<img>" do
-    let(:html) { <<-HTML.strip }
-<img src="http://helvetica.com/image.gif" title="art party organic" alt="messenger bag skateboard" />
-
-    HTML
-
-    it { should == <<-MD.strip }
+    specify 'converts as ![]()' do
+      expect(<<-HTML.strip
+        <img src="http://helvetica.com/image.gif" title="art party organic" alt="messenger bag skateboard" />
+      HTML
+      ).to convert_to <<-MD.strip
 ![messenger bag skateboard](http://helvetica.com/image.gif "art party organic")
-    MD
+      MD
+    end
   end
 
   context "<p>" do
-    let(:html) { <<-HTML.strip }
+    specify 'converts as plaintext' do
+      expect(<<-HTML.strip
 <p>• Bullet 1</p>
 <p>• Bullet 2</p>
 <p>messenger <strong>bag</strong> skateboard</p>
@@ -44,9 +51,8 @@ organic</p>
 <p>• Bullet 3</p>
 <p>• Bullet 4</p>
 <p>Something else</p>
-    HTML
-
-    it { should == <<-MD.strip }
+      HTML
+      ).to convert_to <<-MD.strip
 * Bullet 1
 * Bullet 2
 
@@ -59,11 +65,13 @@ organic
 * Bullet 4
 
 Something else
-    MD
+      MD
+    end
   end
 
   context "<ul>" do
-    let(:html) { <<-HTML.strip }
+    specify 'converts as list' do
+      expect(<<-HTML.strip
 <ul>
   <li>messenger</li>
   <li><strong>bag</strong></li>
@@ -80,9 +88,8 @@ Something else
   <li>• Bullet 1</li>
   <li>• Bullet 2</li>
 </ul>
-    HTML
-
-    it { should == <<-MD.strip }
+      HTML
+      ).to convert_to <<-MD.strip
 * messenger
 * **bag**
 * skateboard
@@ -95,11 +102,13 @@ Something else
 
 * Bullet 1
 * Bullet 2
-    MD
+      MD
+    end
   end
 
   context "<ol>" do
-    let(:html) { <<-HTML.strip }
+    specify 'converts as numbered list' do
+      expect(<<-HTML.strip
 <ol>
   <li>messenger</li>
   <li><strong>bag</strong></li>
@@ -111,9 +120,8 @@ Something else
   <li><p><strong>bag</strong></p></li>
   <li><p>skateboard</p></li>
 </ol>
-    HTML
-
-    it { should == <<-MD.strip }
+      HTML
+      ).to convert_to <<-MD.strip
 1. messenger
 2. **bag**
 3. skateboard
@@ -123,27 +131,29 @@ Something else
 2. **bag**
 
 3. skateboard
-    MD
+      MD
+    end
   end
 
   context "<h1>, <h2>, <h3>, <h4>, <h5>, <h6>" do
-    let(:html) { <<-HTML.strip }
+    specify 'converts as #' do
+      expect(<<-HTML.strip
 <h1>messenger bag skateboard</h1>
 <h2>messenger bag skateboard</h2>
 <h3>messenger bag skateboard</h3>
 <h4>messenger bag skateboard</h4>
 <h5>messenger bag skateboard</h5>
 <h6>messenger bag skateboard</h6>
-    HTML
-
-    it { should == <<-MD.strip }
+      HTML
+      ).to convert_to <<-MD.strip
 # messenger bag skateboard
 ## messenger bag skateboard
 ### messenger bag skateboard
 #### messenger bag skateboard
 ##### messenger bag skateboard
 ###### messenger bag skateboard
-    MD
+      MD
+    end
   end
 
   context "block-level elements" do
@@ -153,7 +163,9 @@ Something else
 <div id="tofu" class="art party">messenger <strong>bag</strong> skateboard</div>
       HTML
 
-      it { should == html }
+      specify 'are left alone' do
+        expect(html).to convert_to html
+      end
     end
 
     context "<table>" do
@@ -171,7 +183,9 @@ Something else
 </table>
       HTML
 
-      it { should == html }
+      specify 'are left alone' do
+        expect(html).to convert_to html
+      end
     end
 
     context "<pre>" do
@@ -183,26 +197,30 @@ Something else
 </pre>
       HTML
 
-      it { should == html }
+      specify 'are left alone' do
+        expect(html).to convert_to html
+      end
     end
   end
 
   context "span-level elements" do
     context "<span>" do
-      let(:html) { <<-HTML.strip }
+      specify 'converts as ' do
+        expect(<<-HTML.strip
 <span>messenger <strong>bag</strong> skateboard</span>
-      HTML
-
-      it { should == <<-MD.strip }
+        HTML
+        ).to convert_to <<-MD.strip
 <span>messenger **bag** skateboard</span>
-      MD
+        MD
+      end
     end
   end
 
   context "plain text" do
-    let(:html) { "• Bullet 1\n• Bullet 2\n" }
-    it 'converts plain bullet points to text' do
-      expect(subject).to eq "* Bullet 1\n* Bullet 2"
+    it 'containing plain bullet points converts to markdown' do
+      expect(
+        "• Bullet 1\n• Bullet 2\n"
+      ).to convert_to "* Bullet 1\n* Bullet 2"
     end
   end
 

--- a/spec/acceptance/upmark_spec.rb
+++ b/spec/acceptance/upmark_spec.rb
@@ -1,5 +1,3 @@
-require "spec_helper"
-
 describe Upmark, ".convert" do
   subject { Upmark.convert(html) }
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -13,4 +13,5 @@ require "upmark"
 
 RSpec.configure do |config|
   config.disable_monkey_patching!
+  config.order = :random
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -10,3 +10,7 @@ if ENV["BUILDBOX"]
 end
 
 require "upmark"
+
+RSpec.configure do |config|
+  config.disable_monkey_patching!
+end

--- a/spec/unit/lib/upmark/parser/xml_spec.rb
+++ b/spec/unit/lib/upmark/parser/xml_spec.rb
@@ -1,5 +1,3 @@
-require "spec_helper"
-
 describe Upmark::Parser::XML do
   let(:parser) { Upmark::Parser::XML.new }
 

--- a/spec/unit/lib/upmark/parser/xml_spec.rb
+++ b/spec/unit/lib/upmark/parser/xml_spec.rb
@@ -1,4 +1,4 @@
-describe Upmark::Parser::XML do
+RSpec.describe Upmark::Parser::XML do
   let(:parser) { Upmark::Parser::XML.new }
 
   context "#node" do

--- a/spec/unit/lib/upmark/parser/xml_spec.rb
+++ b/spec/unit/lib/upmark/parser/xml_spec.rb
@@ -2,101 +2,208 @@ RSpec.describe Upmark::Parser::XML do
   let(:parser) { Upmark::Parser::XML.new }
 
   context "#node" do
-    subject { parser.node }
-
-    it { should parse "" }
-    it { should parse "messenger bag skateboard" }
-    it { should parse "<p>messenger bag skateboard</p>" }
-    it { should parse "messenger <p>bag</p> skateboard" }
-    it { should parse "<p>messenger</p><p>bag</p><p>skateboard</p>" }
-    it { should parse "<p>messenger</p>\n<p>bag</p>\n<p>skateboard</p>" }
-    it { should parse "<p>messenger <strong>bag</strong> skateboard</p>" }
+    it 'will parse ""' do
+      expect(parser.node).to parse ""
+    end
+    it 'will parse "messenger bag skateboard"' do
+      expect(parser.node).to parse "messenger bag skateboard"
+    end
+    it 'will parse "<p>messenger bag skateboard</p>"' do
+      expect(
+        parser.node
+      ).to parse "<p>messenger bag skateboard</p>"
+    end
+    it 'will parse "messenger <p>bag</p> skateboard"' do
+      expect(
+        parser.node
+      ).to parse "messenger <p>bag</p> skateboard"
+    end
+    it 'will parse "<p>messenger</p><p>bag</p><p>skateboard</p>"' do
+      expect(
+        parser.node
+      ).to parse "<p>messenger</p><p>bag</p><p>skateboard</p>"
+    end
+    it 'will parse "<p>messenger</p>\n<p>bag</p>\n<p>skateboard</p>"' do
+      expect(
+        parser.node
+      ).to parse "<p>messenger</p>\n<p>bag</p>\n<p>skateboard</p>"
+    end
+    it 'will parse "<p>messenger <strong>bag</strong> skateboard</p>"' do
+      expect(
+        parser.node
+      ).to parse "<p>messenger <strong>bag</strong> skateboard</p>"
+    end
   end
 
   context "#element" do
-    subject { parser.element }
-
-    it { should     parse "<p></p>" }
-    it { should     parse "<p>messenger bag skateboard</p>" }
-    it { should     parse %q{<tofu art="party" />} }
-    it { should_not parse "<p>" }
-    it { should_not parse "<p>messenger bag skateboard" }
-    it { should_not parse "messenger bag skateboard</p>" }
-    it { should_not parse "<p>messenger bag skateboard<p>" }
+    it 'will parse "<p></p>"' do
+      expect(parser.element).to parse "<p></p>"
+    end
+    it 'will parse "<p>messenger bag skateboard</p>"' do
+      expect(parser.element).to parse "<p>messenger bag skateboard</p>"
+    end
+    it 'will parse %q{<tofu art="party" />}' do
+      expect(parser.element).to parse %q{<tofu art="party" />}
+    end
+    it 'will not parse "<p>"' do
+      expect(parser.element).to_not parse "<p>"
+    end
+    it 'will not parse "<p>messenger bag skateboard"' do
+      expect(parser.element).to_not parse "<p>messenger bag skateboard"
+    end
+    it 'will not parse "messenger bag skateboard</p>"' do
+      expect(parser.element).to_not parse "messenger bag skateboard</p>"
+    end
+    it 'will not parse "<p>messenger bag skateboard<p>"' do
+      expect(parser.element).to_not parse "<p>messenger bag skateboard<p>"
+    end
   end
 
   context "#text" do
-    subject { parser.text }
-
-    it { should     parse "messenger bag skateboard" }
-    it { should_not parse "<p>messenger bag skateboard</p>" }
-    it { should_not parse "" }
+    it 'will parse "messenger bag skateboard"' do
+      expect(parser.text).to parse "messenger bag skateboard"
+    end
+    it 'will not parse "<p>messenger bag skateboard</p>"' do
+      expect(parser.text).to_not parse "<p>messenger bag skateboard</p>"
+    end
+    it 'will not parse ""' do
+      expect(parser.text).to_not parse ""
+    end
   end
 
   context "#start_tag" do
     subject { parser.start_tag }
 
-    it { should     parse %q{<tofu art="party">} }
-    it { should     parse %q{<tofu art="party" synth="letterpress">} }
-    it { should     parse "<tofu>" }
-    it { should_not parse "</tofu>" }
-    it { should_not parse "<tofu" }
-    it { should_not parse "tofu>" }
+    it 'will parse %q{<tofu art="party">}' do
+      expect(parser.start_tag).to parse %q{<tofu art="party">}
+    end
+    it 'will parse %q{<tofu art="party" synth="letterpress">}' do
+      expect(parser.start_tag).to parse %q{<tofu art="party" synth="letterpress">}
+    end
+    it 'will parse "<tofu>"' do
+      expect(parser.start_tag).to parse "<tofu>"
+    end
+    it 'will not parse "</tofu>"' do
+      expect(parser.start_tag).to_not parse "</tofu>"
+    end
+    it 'will not parse "<tofu"' do
+      expect(parser.start_tag).to_not parse "<tofu"
+    end
+    it 'will not parse "tofu>"' do
+      expect(parser.start_tag).to_not parse "tofu>"
+    end
   end
 
   context "#end_tag" do
     subject { parser.end_tag }
 
-    it { should     parse "</tofu>" }
-    it { should_not parse "<tofu>" }
-    it { should_not parse "<tofu" }
-    it { should_not parse "/tofu>" }
+    it 'will parse "</tofu>"' do
+      expect(parser.end_tag).to parse "</tofu>"
+    end
+    it 'will not parse "<tofu>"' do
+      expect(parser.end_tag).to_not parse "<tofu>"
+    end
+    it 'will not parse "<tofu"' do
+      expect(parser.end_tag).to_not parse "<tofu"
+    end
+    it 'will not parse "/tofu>"' do
+      expect(parser.end_tag).to_not parse "/tofu>"
+    end
   end
 
   context "#empty_tag" do
     subject { parser.empty_tag }
 
-    it { should     parse %q{<tofu />} }
-    it { should     parse %q{<tofu art="party" />} }
-    it { should     parse %q{<tofu art="party" synth="letterpress" />} }
-    it { should_not parse "<tofu>" }
-    it { should_not parse "</tofu>" }
-    it { should_not parse "<tofu" }
-    it { should_not parse "/tofu>" }
+    it 'will parse %q{<tofu />}' do
+      expect(parser.empty_tag).to parse %q{<tofu />}
+    end
+    it 'will parse %q{<tofu art="party" />}' do
+      expect(parser.empty_tag).to parse %q{<tofu art="party" />}
+    end
+    it 'will parse %q{<tofu art="party" synth="letterpress" />}' do
+      expect(parser.empty_tag).to parse %q{<tofu art="party" synth="letterpress" />}
+    end
+    it 'will not parse "<tofu>"' do
+      expect(parser.empty_tag).to_not parse "<tofu>"
+    end
+    it 'will not parse "</tofu>"' do
+      expect(parser.empty_tag).to_not parse "</tofu>"
+    end
+    it 'will not parse "<tofu"' do
+      expect(parser.empty_tag).to_not parse "<tofu"
+    end
+    it 'will not parse "/tofu>"' do
+      expect(parser.empty_tag).to_not parse "/tofu>"
+    end
   end
 
   context "#name" do
     subject { parser.name }
 
-    it { should     parse "p" }
-    it { should     parse "h1" }
-    it { should_not parse "1h" }
-    it { should_not parse "h 1" }
+    it 'will parse "p"' do
+      expect(parser.name).to parse "p"
+    end
+    it 'will parse "h1"' do
+      expect(parser.name).to parse "h1"
+    end
+    it 'will not parse "1h"' do
+      expect(parser.name).to_not parse "1h"
+    end
+    it 'will not parse "h 1"' do
+      expect(parser.name).to_not parse "h 1"
+    end
   end
 
   context "#attribute" do
     subject { parser.attribute }
 
-    it { should     parse %q{art="party organic"} }
-    it { should     parse %q{art='party organic'} }
-    it { should     parse %q{art="party'organic"} }
-    it { should     parse %q{art='party"organic'} }
-    it { should_not parse "art" }
-    it { should_not parse "art=" }
-    it { should_not parse "art=party" }
-    it { should_not parse %q{="party organic"} }
-    it { should_not parse %q{art="party organic'} }
-    it { should_not parse %q{art='party organic"} }
+    it 'will parse %q{art="party organic"}' do
+      expect(parser.attribute).to parse %q{art="party organic"}
+    end
+    it 'will parse %q{art=\'party organic\'}' do
+      expect(parser.attribute).to parse %q{art='party organic'}
+    end
+    it 'will parse %q{art="party\'organic"}' do
+      expect(parser.attribute).to parse %q{art="party'organic"}
+    end
+    it 'will parse %q{art=\'party"organic\'}' do
+      expect(parser.attribute).to parse %q{art='party"organic'}
+    end
+    it 'will not parse "art"' do
+      expect(parser.attribute).to_not parse "art"
+    end
+    it 'will not parse "art="' do
+      expect(parser.attribute).to_not parse "art="
+    end
+    it 'will not parse "art=party"' do
+      expect(parser.attribute).to_not parse "art=party"
+    end
+    it 'will not parse %q{="party organic"}' do
+      expect(parser.attribute).to_not parse %q{="party organic"}
+    end
+    it 'will not parse %q{art="party organic\'}' do
+      expect(parser.attribute).to_not parse %q{art="party organic'}
+    end
+    it 'will not parse %q{art=\'party organic"}' do
+      expect(parser.attribute).to_not parse %q{art='party organic"}
+    end
   end
 
   context "#parse" do
-    subject { parser.parse(html) }
+    RSpec::Matchers.define :convert do |html|
+      match do |parser|
+        parser.parse(html) == ast
+      end
+
+      chain :to do |ast|
+        @ast = ast
+      end
+      attr_reader :ast
+    end
 
     context "single tag" do
-      let(:html) { "<p>messenger</p>" }
-
-      it do
-        should == [
+      it 'is parsed as a single element' do
+        expect(parser).to convert("<p>messenger</p>").to([
           {
             element: {
               start_tag: {name: "p", attributes: []},
@@ -104,29 +211,27 @@ RSpec.describe Upmark::Parser::XML do
               children:  [{text: "messenger"}]
             }
           }
-        ]
+        ])
       end
     end
 
     context "empty tag" do
-      let(:html) { "<br />" }
-
-      it do
-        should == [
+      it 'is parsed an empty_tag element' do
+        expect(parser).to convert("<br />").to([
           {
             element: {
               empty_tag: {name: "br", attributes: []}
             }
           }
-        ]
+        ])
       end
     end
 
     context "single tag with attributes" do
       let(:html) { %q{<a href="http://helvetica.com/" title="art party organic">messenger bag skateboard</a>} }
 
-      it do
-        should == [
+      it 'is parsed an element with an attribute subtree' do
+        expect(parser).to convert(html).to([
           {
             element: {
               start_tag: {
@@ -140,15 +245,15 @@ RSpec.describe Upmark::Parser::XML do
               children: [{text: "messenger bag skateboard"}]
             }
           }
-        ]
+        ])
       end
     end
 
     context "multiple inline tags" do
       let(:html) { "<p>messenger</p><p>bag</p><p>skateboard</p>" }
 
-      it do
-        should == [
+      it 'converts to multiple elements' do
+        expect(parser).to convert(html).to([
           {
             element: {
               start_tag: {name: "p", attributes: []},
@@ -168,15 +273,15 @@ RSpec.describe Upmark::Parser::XML do
               children:  [{text: "skateboard"}]
             }
           }
-        ]
+        ])
       end
     end
 
     context "multiple tags" do
       let(:html) { "<p>messenger</p>\n<p>bag</p>\n<p>skateboard</p>" }
 
-      it do
-        should == [
+      it 'converts to multiple elements' do
+        expect(parser).to convert(html).to([
           {
             element: {
               start_tag: {name: "p", attributes: []},
@@ -200,15 +305,15 @@ RSpec.describe Upmark::Parser::XML do
               children:  [{text: "skateboard"}]
             }
           }
-        ]
+        ])
       end
     end
 
     context "nested tags" do
       let(:html) { "<p>messenger <strong>bag</strong> skateboard</p>" }
 
-      it do
-        should == [
+      it 'converts to multiple nested elements' do
+        expect(parser).to convert(html).to([
           {
             element: {
               start_tag: {name: "p", attributes: []},
@@ -228,7 +333,7 @@ RSpec.describe Upmark::Parser::XML do
               ]
             }
           }
-        ]
+        ])
       end
     end
   end

--- a/spec/unit/lib/upmark/transform/markdown_spec.rb
+++ b/spec/unit/lib/upmark/transform/markdown_spec.rb
@@ -1,4 +1,4 @@
-describe Upmark::Transform::Markdown do
+RSpec.describe Upmark::Transform::Markdown do
   let(:transform) { Upmark::Transform::Markdown.new }
 
   context "#apply" do

--- a/spec/unit/lib/upmark/transform/markdown_spec.rb
+++ b/spec/unit/lib/upmark/transform/markdown_spec.rb
@@ -1,5 +1,3 @@
-require "spec_helper"
-
 describe Upmark::Transform::Markdown do
   let(:transform) { Upmark::Transform::Markdown.new }
 

--- a/spec/unit/lib/upmark/transform/markdown_spec.rb
+++ b/spec/unit/lib/upmark/transform/markdown_spec.rb
@@ -1,9 +1,7 @@
 RSpec.describe Upmark::Transform::Markdown do
-  let(:transform) { Upmark::Transform::Markdown.new }
+  let(:transformed_ast) { Upmark::Transform::Markdown.new.apply(ast) }
 
   context "#apply" do
-    subject { transform.apply(ast) }
-
     context "<p>" do
       context "single tag" do
         let(:ast) do
@@ -19,7 +17,11 @@ RSpec.describe Upmark::Transform::Markdown do
           ]
         end
 
-        it { should == ["messenger bag skateboard\n\n"] }
+        it 'transforms to markdown' do
+          expect(
+            transformed_ast
+          ).to eq(["messenger bag skateboard\n\n"])
+        end
       end
 
       context "multiple tags" do
@@ -50,7 +52,11 @@ RSpec.describe Upmark::Transform::Markdown do
           ]
         end
 
-        it { should == ["messenger\n\n", "bag\n\n", "skateboard\n\n"] }
+        it 'transforms to markdown' do
+          expect(
+            transformed_ast
+          ).to eq(["messenger\n\n", "bag\n\n", "skateboard\n\n"])
+        end
       end
     end
 
@@ -72,7 +78,11 @@ RSpec.describe Upmark::Transform::Markdown do
           ]
         end
 
-        it { should == [%q{[messenger bag skateboard](http://helvetica.com/ "art party organic")}] }
+        it 'transforms to markdown' do
+          expect(
+            transformed_ast
+          ).to eq([%q{[messenger bag skateboard](http://helvetica.com/ "art party organic")}])
+        end
       end
     end
 
@@ -95,7 +105,11 @@ RSpec.describe Upmark::Transform::Markdown do
           ]
         end
 
-        it { should == [%q{![messenger bag skateboard](http://helvetica.com/image.gif "art party organic")}] }
+        it 'transforms to markdown' do
+          expect(
+            transformed_ast
+          ).to eq([%q{![messenger bag skateboard](http://helvetica.com/image.gif "art party organic")}])
+        end
       end
     end
   end

--- a/upmark.gemspec
+++ b/upmark.gemspec
@@ -19,5 +19,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency "rake"
   s.add_development_dependency "simplecov"
 
-  s.add_runtime_dependency "parslet", "1.4.0"
+  s.add_runtime_dependency "parslet", "~> 1.6.0"
 end

--- a/upmark.gemspec
+++ b/upmark.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.test_files  =  Dir.glob("{spec}/**/*")
   s.executables = ["upmark"]
 
-  s.add_development_dependency "rspec", "~> 2.0", "< 2.99"
+  s.add_development_dependency "rspec", "~> 2.0", "< 3"
   s.add_development_dependency "rake"
   s.add_development_dependency "simplecov"
 

--- a/upmark.gemspec
+++ b/upmark.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.test_files  =  Dir.glob("{spec}/**/*")
   s.executables = ["upmark"]
 
-  s.add_development_dependency "rspec", "~> 2.0", "< 3"
+  s.add_development_dependency "rspec", "~> 3.3"
   s.add_development_dependency "rake"
   s.add_development_dependency "simplecov"
 

--- a/upmark.gemspec
+++ b/upmark.gemspec
@@ -19,5 +19,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency "rake"
   s.add_development_dependency "simplecov"
 
-  s.add_runtime_dependency "parslet", "~> 1.6.0"
+  s.add_runtime_dependency "parslet", "~> 1.7.0"
 end


### PR DESCRIPTION
This upgrades RSpec in stages, makes some best practise improvements to the specs (removing manual requires of the spec helper, turning on zero monkey patching mode, randomising the ordering), then improves the specs by adding descriptions and a few custom matchers for readability.

Additionally this upgrades parslet to the latest version.
