### PR TITLE
Strip table tags whilst processing internal text as markdown

### DIFF
--- a/lib/upmark.rb
+++ b/lib/upmark.rb
@@ -24,6 +24,9 @@ module Upmark
     # The result is either a String or an Array.
     ast = ast.join if ast.is_a?(Array)
 
+    # Remove trailing whitespace
+    ast.gsub!(/ +$/,'')
+
     # Compress bullet point lists
     ast.gsub!(/^•\s*([^•\n]*)\n+(?=•)/,"* #{'\1'}\n")
 

--- a/lib/upmark/parser/xml.rb
+++ b/lib/upmark/parser/xml.rb
@@ -45,6 +45,10 @@ module Upmark
         str('>')
       end
 
+      rule(:empty_br) do
+        str('<') >> space? >> str('br').as(:name) >> space? >> str('>')
+      end
+
       rule(:empty_tag) do
         str('<') >>
         name.as(:name) >>

--- a/lib/upmark/parser/xml.rb
+++ b/lib/upmark/parser/xml.rb
@@ -10,68 +10,68 @@ module Upmark
     class XML < Parslet::Parser
       root(:node)
 
-      rule(:node) {
+      rule(:node) do
         (
           element.as(:element) |
           text.as(:text)
         ).repeat(0)
-      }
+      end
 
-      rule(:element) {
+      rule(:element) do
         (
           start_tag.as(:start_tag) >>
           node.as(:children) >>
           end_tag.as(:end_tag)
         ) |
         empty_tag.as(:empty_tag)
-      }
+      end
 
-      rule(:text) {
+      rule(:text) do
         match(/[^<>]/).repeat(1)
-      }
+      end
 
-      rule(:start_tag) {
+      rule(:start_tag) do
         str('<') >>
         name.as(:name) >>
         (space >> attribute).repeat.as(:attributes) >>
         space? >>
         str('>')
-      }
+      end
 
-      rule(:end_tag) {
+      rule(:end_tag) do
         str('</') >>
         name.as(:name) >>
         space? >>
         str('>')
-      }
+      end
 
-      rule(:empty_tag) {
+      rule(:empty_tag) do
         str('<') >>
         name.as(:name) >>
         (space >> attribute).repeat.as(:attributes) >>
         space? >>
         str('/>')
-      }
+      end
 
-      rule(:name) {
+      rule(:name) do
         match(/[a-zA-Z_:]/) >> match(/[\w:\.-]/).repeat
-      }
+      end
 
-      rule(:attribute) {
+      rule(:attribute) do
         name.as(:name) >>
         str('=') >> (
           (str('"') >> double_quoted_attribute_value.as(:value) >> str('"')) | # double quotes
           (str("'") >> single_quoted_attribute_value.as(:value) >> str("'"))   # single quotes
         )
-      }
+      end
 
-      rule(:double_quoted_attribute_value) {
+      rule(:double_quoted_attribute_value) do
         (str('"').absent? >> (match(/[^<&]/) | entity_ref)).repeat
-      }
+      end
 
-      rule(:single_quoted_attribute_value) {
+      rule(:single_quoted_attribute_value) do
         (str("'").absent? >> (match(/[^<&]/) | entity_ref)).repeat
-      }
+      end
 
       rule(:entity_ref) { match("&") >> name >> match(";") }
 

--- a/lib/upmark/parser/xml.rb
+++ b/lib/upmark/parser/xml.rb
@@ -18,6 +18,7 @@ module Upmark
       end
 
       rule(:element) do
+        empty_br |
         (
           start_tag.as(:start_tag) >>
           node.as(:children) >>

--- a/lib/upmark/transform/markdown.rb
+++ b/lib/upmark/transform/markdown.rb
@@ -80,19 +80,6 @@ module Upmark
       element(:br) { "\n" }
       rule(element: { name: "br"}) { "\n" }
 
-      element(:table, :thead, :tbody, :tfoot) do |element|
-        element[:children].reject! { |c| c=~ /^[\n\s]*$/ }
-        element[:children]
-      end
-      element(:tr) do |element|
-        element[:children]
-          .select { |c| Array === c }
-          .map do |children|
-            children.reject! { |c| c =~ /\A[\n\s]*\Z/ }
-            children.map { |c| c.gsub(/^ +/,'') }.join
-          end
-      end
-      element(:td, :th) { |element| element[:children] }
     end
   end
 end

--- a/lib/upmark/transform/markdown.rb
+++ b/lib/upmark/transform/markdown.rb
@@ -78,6 +78,7 @@ module Upmark
       element(:i, :em)     {|element| "*#{text(element)}*" }
 
       element(:br) { "\n" }
+      rule(element: { name: "br"}) { "\n" }
 
       element(:table, :thead, :tbody, :tfoot) do |element|
         element[:children].reject! { |c| c=~ /^[\n\s]*$/ }

--- a/lib/upmark/transform/markdown.rb
+++ b/lib/upmark/transform/markdown.rb
@@ -35,7 +35,7 @@ module Upmark
       end
 
       def self.text(element)
-        element[:children].join.gsub(/(\n)+/, '\1')
+        element[:children].join.gsub(/(\n)[\n ]+/, '\1')
       end
 
       element(:p)  {|element| "#{text(element)}\n\n" }

--- a/lib/upmark/transform/markdown.rb
+++ b/lib/upmark/transform/markdown.rb
@@ -79,6 +79,19 @@ module Upmark
 
       element(:br) { "\n" }
 
+      element(:table, :thead, :tbody, :tfoot) do |element|
+        element[:children].reject! { |c| c=~ /^[\n\s]*$/ }
+        element[:children]
+      end
+      element(:tr) do |element|
+        element[:children]
+          .select { |c| Array === c }
+          .map do |children|
+            children.reject! { |c| c =~ /\A[\n\s]*\Z/ }
+            children.map { |c| c.gsub(/^ +/,'') }.join
+          end
+      end
+      element(:td, :th) { |element| element[:children] }
     end
   end
 end

--- a/lib/upmark/transform/preprocess.rb
+++ b/lib/upmark/transform/preprocess.rb
@@ -17,6 +17,33 @@ module Upmark
           }
         }
       end
+
+      # table content elements are stripped ignoring their spacing
+      element(:table, :thead, :tbody, :tfoot) do |element|
+        element[:children].reject! do |c|
+          Hash === c && c[:text].to_s =~ /\A[\n ]*\Z/m
+        end
+        element[:children]
+      end
+
+      # table content elements are stripped
+      element(:td, :th) do |element|
+        element[:children]
+      end
+
+      # table rows are treated as 'paragraph' blocks
+      element(:tr) do |element|
+        element[:children]
+          .select { |c| Array === c }
+          .map do |children|
+            children.map do |child|
+              if child[:text]
+                child[:text].to_s.gsub!(/^\n */,'')
+              end
+              child
+            end + ["\n"]
+          end + ["\n"]
+      end
     end
   end
 end

--- a/lib/upmark/transform/preprocess.rb
+++ b/lib/upmark/transform/preprocess.rb
@@ -7,7 +7,7 @@ module Upmark
     class Preprocess < Parslet::Transform
       include TransformHelpers
 
-      element(:div, :table, :pre) do |element|
+      element(:div, :pre) do |element|
         {
           element: {
             name:       element[:name],

--- a/spec/acceptance/upmark_spec.rb
+++ b/spec/acceptance/upmark_spec.rb
@@ -196,9 +196,13 @@ Something else
     <td><p><strong>bag</strong></p></td>
   </tr>
   <tr>
-    <td>skateboarding </td>
+    <td>skateboarding</td>
     <td>is cool with all the kids<br/>
       or something</td>
+  </tr>
+  <tr>
+    <td><strong>Messenger bags</strong></td>
+    <td>are in with the hipsters though.</td>
   </tr>
 </table>
       HTML
@@ -213,8 +217,12 @@ messenger
 
 **bag**
 
-skateboarding is cool with all the kids
+skateboarding
+is cool with all the kids
 or something
+
+**Messenger bags**
+are in with the hipsters though.
         MD
       end
     end

--- a/spec/acceptance/upmark_spec.rb
+++ b/spec/acceptance/upmark_spec.rb
@@ -197,8 +197,8 @@ Something else
   </tr>
   <tr>
     <td>skateboarding</td>
-    <td>is cool with all the kids<br/>
-      or something</td>
+    <td><p>is cool with all the kids<br/>
+      or something</p></td>
   </tr>
   <tr>
     <td><strong>Messenger bags</strong></td>

--- a/spec/acceptance/upmark_spec.rb
+++ b/spec/acceptance/upmark_spec.rb
@@ -188,19 +188,34 @@ Something else
       let(:html) { <<-HTML.strip }
 <table>
   <tr>
-    <td>messenger</td>
+    <td><p><strong>messenger</strong></p></td>
+    <td><p>bag</p></td>
   </tr>
   <tr>
-    <td><strong>bag</strong></td>
+    <td><p>messenger</p></td>
+    <td><p><strong>bag</strong></p></td>
   </tr>
   <tr>
-    <td>skateboard</td>
+    <td>skateboarding </td>
+    <td>is cool with all the kids<br/>
+      or something</td>
   </tr>
 </table>
       HTML
 
-      specify 'are left alone' do
-        expect(html).to convert_to html
+      specify 'is converted to paragraphs' do
+        expect(html).to convert_to <<-MD.strip
+**messenger**
+
+bag
+
+messenger
+
+**bag**
+
+skateboarding is cool with all the kids
+or something
+        MD
       end
     end
 

--- a/spec/unit/lib/upmark/parser/xml_spec.rb
+++ b/spec/unit/lib/upmark/parser/xml_spec.rb
@@ -107,6 +107,12 @@ RSpec.describe Upmark::Parser::XML do
     end
   end
 
+  context "#empty_br" do
+    it 'will parse html br tags' do
+      expect(parser.empty_br).to parse '<br>'
+    end
+  end
+
   context "#empty_tag" do
     it 'will parse %q{<tofu />}' do
       expect(parser.empty_tag).to parse %q{<tofu />}

--- a/spec/unit/lib/upmark/parser/xml_spec.rb
+++ b/spec/unit/lib/upmark/parser/xml_spec.rb
@@ -72,8 +72,6 @@ RSpec.describe Upmark::Parser::XML do
   end
 
   context "#start_tag" do
-    subject { parser.start_tag }
-
     it 'will parse %q{<tofu art="party">}' do
       expect(parser.start_tag).to parse %q{<tofu art="party">}
     end
@@ -95,8 +93,6 @@ RSpec.describe Upmark::Parser::XML do
   end
 
   context "#end_tag" do
-    subject { parser.end_tag }
-
     it 'will parse "</tofu>"' do
       expect(parser.end_tag).to parse "</tofu>"
     end
@@ -112,8 +108,6 @@ RSpec.describe Upmark::Parser::XML do
   end
 
   context "#empty_tag" do
-    subject { parser.empty_tag }
-
     it 'will parse %q{<tofu />}' do
       expect(parser.empty_tag).to parse %q{<tofu />}
     end
@@ -138,8 +132,6 @@ RSpec.describe Upmark::Parser::XML do
   end
 
   context "#name" do
-    subject { parser.name }
-
     it 'will parse "p"' do
       expect(parser.name).to parse "p"
     end
@@ -155,8 +147,6 @@ RSpec.describe Upmark::Parser::XML do
   end
 
   context "#attribute" do
-    subject { parser.attribute }
-
     it 'will parse %q{art="party organic"}' do
       expect(parser.attribute).to parse %q{art="party organic"}
     end

--- a/spec/unit/lib/upmark/parser/xml_spec.rb
+++ b/spec/unit/lib/upmark/parser/xml_spec.rb
@@ -8,6 +8,9 @@ RSpec.describe Upmark::Parser::XML do
     it 'will parse "messenger bag skateboard"' do
       expect(parser.node).to parse "messenger bag skateboard"
     end
+    it 'will parse html br tags' do
+      expect(parser.node).to parse '<p>One<br>Two</p>'
+    end
     it 'will parse "<p>messenger bag skateboard</p>"' do
       expect(
         parser.node
@@ -41,6 +44,9 @@ RSpec.describe Upmark::Parser::XML do
     end
     it 'will parse "<p>messenger bag skateboard</p>"' do
       expect(parser.element).to parse "<p>messenger bag skateboard</p>"
+    end
+    it 'will parse "<p>Some<br>Text</p>"' do
+      expect(parser.element).to parse "<p>Some<br>Text</p>"
     end
     it 'will parse %q{<tofu art="party" />}' do
       expect(parser.element).to parse %q{<tofu art="party" />}

--- a/spec/unit/lib/upmark/transform/markdown_spec.rb
+++ b/spec/unit/lib/upmark/transform/markdown_spec.rb
@@ -2,6 +2,14 @@ RSpec.describe Upmark::Transform::Markdown do
   let(:transformed_ast) { Upmark::Transform::Markdown.new.apply(ast) }
 
   context "#apply" do
+    context '<br>' do
+      let(:ast) { [{ element: { name: 'br' }}] }
+
+      it 'will transform to markdown' do
+        expect(transformed_ast).to eq ["\n"]
+      end
+    end
+
     context "<p>" do
       context "single tag" do
         let(:ast) do


### PR DESCRIPTION
This turns tables into something more intelligible.