### PR TITLE
Raise error on invalid markup

### DIFF
--- a/lib/upmark/transform/normalise.rb
+++ b/lib/upmark/transform/normalise.rb
@@ -3,13 +3,19 @@ module Upmark
     # A transform class withich normalises start/end/empty tags into the
     # same structure.
     class Normalise < Parslet::Transform
+
+      rule(element: subtree(:invalid)) do
+        raise Upmark::ParseFailed
+      end
+
       rule(
         element: {
           start_tag: {name: simple(:name), attributes: subtree(:attributes)},
-          end_tag:   {name: simple(:name)},
+          end_tag:   {name: simple(:end_tag_name)},
           children:  subtree(:children)
         }
       ) do
+        raise Upmark::ParseFailed unless name == end_tag_name
         {
           element: {
             name:       name,
@@ -34,6 +40,7 @@ module Upmark
           }
         }
       end
+
     end
   end
 end

--- a/spec/acceptance/upmark_spec.rb
+++ b/spec/acceptance/upmark_spec.rb
@@ -272,4 +272,14 @@ are in with the hipsters though.
       }.to raise_error(Upmark::ParseFailed)
     end
   end
+
+  context "unbalanced elements" do
+    let(:html) { "<p>foo</b>" }
+
+    it "should raise an exception" do
+      expect {
+        Upmark.convert(html)
+      }.to raise_error(Upmark::ParseFailed)
+    end
+  end
 end


### PR DESCRIPTION
handle edgecases where invalid syntax is generated with parse errors