### PR TITLE
Strip <span> tags

### DIFF
--- a/lib/upmark/transform/preprocess.rb
+++ b/lib/upmark/transform/preprocess.rb
@@ -18,6 +18,10 @@ module Upmark
         }
       end
 
+      element(:span) do |element|
+        element[:children]
+      end
+
       # table content elements are stripped ignoring their spacing
       element(:table, :thead, :tbody, :tfoot) do |element|
         element[:children].reject! do |c|

--- a/spec/acceptance/upmark_spec.rb
+++ b/spec/acceptance/upmark_spec.rb
@@ -242,16 +242,14 @@ are in with the hipsters though.
     end
   end
 
-  context "span-level elements" do
-    context "<span>" do
-      specify 'converts as ' do
-        expect(<<-HTML.strip
+  context "<span> elements" do
+    specify 'are stripped' do
+      expect(<<-HTML.strip
 <span>messenger <strong>bag</strong> skateboard</span>
-        HTML
-        ).to convert_to <<-MD.strip
-<span>messenger **bag** skateboard</span>
-        MD
-      end
+      HTML
+      ).to convert_to <<-MD.strip
+messenger **bag** skateboard
+      MD
     end
   end
 


### PR DESCRIPTION
`<span>` tags are used for styling mostly which doesn't translate via our markdown so remove them