### PR TITLE
Strip empty tags

### DIFF
--- a/lib/upmark/parser/xml.rb
+++ b/lib/upmark/parser/xml.rb
@@ -12,9 +12,16 @@ module Upmark
 
       rule(:node) do
         (
+          empty_element.as(:empty) |
           element.as(:element) |
           text.as(:text)
         ).repeat(0)
+      end
+
+      rule(:empty_element) do
+        start_tag.as(:start_tag) >>
+        match(/\s+/) >>
+        end_tag.as(:end_tag)
       end
 
       rule(:element) do
@@ -28,6 +35,7 @@ module Upmark
       end
 
       rule(:text) do
+        match(/\A[\s\n\t ]+\Z/m).absent? >> # ignore entirely empty strings
         match(/[^<>]/).repeat(1)
       end
 

--- a/lib/upmark/transform/normalise.rb
+++ b/lib/upmark/transform/normalise.rb
@@ -8,6 +8,11 @@ module Upmark
         raise Upmark::ParseFailed
       end
 
+      # Strip empty tags
+      rule(empty: subtree(:invalid)) do
+        ' '
+      end
+
       rule(
         element: {
           start_tag: {name: simple(:name), attributes: subtree(:attributes)},

--- a/spec/acceptance/upmark_spec.rb
+++ b/spec/acceptance/upmark_spec.rb
@@ -54,6 +54,9 @@ RSpec.describe Upmark, ".convert" do
 <p>art party<br />
 organic</p>
 
+<p> </p>
+<p><strong> </strong></p>
+
 <p>• Bullet 3</p>
 <p>• Bullet 4</p>
 <p>• Bullet 5</p>

--- a/spec/unit/lib/upmark/parser/xml_spec.rb
+++ b/spec/unit/lib/upmark/parser/xml_spec.rb
@@ -194,13 +194,20 @@ RSpec.describe Upmark::Parser::XML do
   context "#parse" do
     RSpec::Matchers.define :convert do |html|
       match do |parser|
-        parser.parse(html) == ast
+        @actual = parser.parse(html)
+        @actual == @expected
       end
 
       chain :to do |ast|
-        @ast = ast
+        @expected = ast
       end
-      attr_reader :ast
+      attr_reader :expected
+
+      failure_message do
+        %Q{expected "#{html}" to parse to "#{@expected.inspect}" but was #{@result.inspect}}
+      end
+
+      diffable
     end
 
     context "single tag" do

--- a/spec/unit/lib/upmark/parser/xml_spec.rb
+++ b/spec/unit/lib/upmark/parser/xml_spec.rb
@@ -38,6 +38,12 @@ RSpec.describe Upmark::Parser::XML do
     end
   end
 
+  context "#empty_element" do
+    it 'will parse <p> </p>' do
+      expect(parser.empty_element).to parse '<p> </p>'
+    end
+  end
+
   context "#element" do
     it 'will parse "<p></p>"' do
       expect(parser.element).to parse "<p></p>"
@@ -71,6 +77,9 @@ RSpec.describe Upmark::Parser::XML do
     end
     it 'will not parse "<p>messenger bag skateboard</p>"' do
       expect(parser.text).to_not parse "<p>messenger bag skateboard</p>"
+    end
+    it 'will not parse " "' do
+      expect(parser.text).to_not parse " "
     end
     it 'will not parse ""' do
       expect(parser.text).to_not parse ""
@@ -221,6 +230,20 @@ RSpec.describe Upmark::Parser::XML do
             }
           }
         ])
+      end
+
+      it 'will ignore empty text tags' do
+        expect(parser).to convert('<p> </p>').to(
+          [
+            {
+              empty:
+                {
+                  start_tag: { name: "p", attributes: [] },
+                  end_tag:   { name: "p" },
+                }
+            }
+          ]
+        )
       end
     end
 


### PR DESCRIPTION
Remove empty html tags, they contain no content markdown is interested in.