### PR TITLE
Remove map_with_index monkeypatch.

### DIFF
--- a/lib/core_ext/array.rb
+++ b/lib/core_ext/array.rb
@@ -1,9 +1,0 @@
-class Array
-  def map_with_index
-    result = []
-    each_with_index do |element, index|
-      result << yield(element, index)
-    end
-    result
-  end
-end

--- a/lib/upmark.rb
+++ b/lib/upmark.rb
@@ -1,7 +1,5 @@
 require "parslet"
 
-require "core_ext/array"
-
 require 'upmark/errors'
 require "upmark/parser/xml"
 require 'upmark/transform_helpers'

--- a/lib/upmark/transform/markdown.rb
+++ b/lib/upmark/transform/markdown.rb
@@ -54,7 +54,7 @@ module Upmark
 
       element(:ol) do |element|
         children = element[:children].map {|value| value.strip != "" ? value : nil }.compact
-        children.map_with_index {|value, i| "#{i + 1}. #{value}\n" }
+        children.map.with_index {|value, i| "#{i + 1}. #{value}\n" }
       end
 
       element(:a) do |element|

--- a/upmark.gemspec
+++ b/upmark.gemspec
@@ -9,6 +9,7 @@ Gem::Specification.new do |s|
   s.summary     = %q{A HTML to Markdown converter.}
   s.description = %q{Upmark has the skills to convert your HTML to Markdown.}
 
+  s.required_ruby_version = ">= 1.9.3"
   s.rubyforge_project = "upmark"
 
   s.files       =  Dir.glob("{lib,spec}/**/*") + ["Rakefile","LICENSE","README.md"]


### PR DESCRIPTION
Ruby >= 1.9.3 supports `map.with_index`.