### PR TITLE
Prints ASCII Tree when Parslet fails

### DIFF
--- a/lib/upmark.rb
+++ b/lib/upmark.rb
@@ -36,6 +36,8 @@ module Upmark
 
     ast.strip
   rescue Parslet::ParseFailed => e
+    puts "Parslet Failed, ASCII Tree:"
+    puts e.cause.ascii_tree
     raise Upmark::ParseFailed.new('Parse failed', e)
   end
 end


### PR DESCRIPTION
Added a 'puts' satement to print the Parslet ASCII Tree for errors. 

If the markdown parse fails because of parslet errors, when parsing the HTM, it should print the Parslet ASCII Tree to show why parslet failed. Without this, discerning what caused fatal Parslet errors that occurred during parsing, are impossible to diagnose.