### PR TITLE
Delegate ascii_tree method to cause object

### DIFF
--- a/lib/upmark/errors.rb
+++ b/lib/upmark/errors.rb
@@ -1,14 +1,14 @@
 module Upmark
   class ParseFailed < StandardError
+    attr_reader :cause
 
     def initialize(message, cause)
       @cause = cause
       super(message)
     end
 
-    def cause
-      @cause
+    def ascii_tree
+      @cause && @cause.ascii_tree
     end
-
   end
 end

--- a/spec/errors_spec.rb
+++ b/spec/errors_spec.rb
@@ -1,0 +1,12 @@
+RSpec.describe Upmark::ParseFailed, ".ascii_tree" do
+  it "delegates to a cause object" do
+    cause = double(ascii_tree: double)
+    error = Upmark::ParseFailed.new("oh noes", cause)
+    expect(error.ascii_tree).to be(cause.ascii_tree)
+  end
+
+  it "returns nil when there is no cause" do
+    error = Upmark::ParseFailed.new("oh noes", nil)
+    expect(error.ascii_tree).to be_nil
+  end
+end


### PR DESCRIPTION
This is just a little sugar to expose the `ascii_tree` method more easily for parsing errors.