### PR TITLE
Add support for nested lists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## Unreleased
+* Add support for nested <ul> lists
+
 ## 1.0.0 / 2018-03-27
 * Delegate `ascii_tree` method to cause object
 * Travis CI

--- a/lib/upmark/transform/markdown.rb
+++ b/lib/upmark/transform/markdown.rb
@@ -48,8 +48,15 @@ module Upmark
       element(:li) {|element| "#{text(element)}" }
 
       element(:ul) do |element|
-        children = element[:children].map {|value| value.strip != "" ? value : nil }.compact
-        children.map {|value| "* #{value.gsub(/^\s*•\s*/,'')}\n" }
+        element[:children].map do |value|
+          if value.is_a? Array
+            # Indent nested lists two spaces
+            value.map { |v| "  #{v}" }
+          else
+            # Prepend "* " and remove unicode •
+            value.strip != "" ? "* #{value.gsub(/^\s*•\s*/,'')}\n" : nil
+          end
+        end.compact
       end
 
       element(:ol) do |element|

--- a/spec/acceptance/upmark_spec.rb
+++ b/spec/acceptance/upmark_spec.rb
@@ -173,6 +173,25 @@ Something else
 * Bullet 2
       MD
     end
+
+    specify 'converts nested ul as list' do
+      expect(<<-HTML.strip
+<ul>
+  <li>messenger</li>
+  <li>bag</li>
+  <ul>
+    <li>electric</li>
+    <li>skateboard</li>
+  </ul>
+</ul>
+      HTML
+      ).to convert_to <<-MD.strip
+* messenger
+* bag
+  * electric
+  * skateboard
+      MD
+    end
   end
 
   context "<ol>" do


### PR DESCRIPTION
We're seeing lots of errors when importing jobs from feeds because upmark doesn't support nested lists, like this:

```
<ul>
  <li>messenger</li>
  <li>bag</li>
  <ul>
    <li>electric</li>
    <li>skateboard</li>
  </ul>
</ul>
```

Modify our markdown generation to support nested lists.