### PR TITLE
Valid HTML may contain unescaped `>` characters in text nodes

### DIFF
--- a/lib/upmark/parser/xml.rb
+++ b/lib/upmark/parser/xml.rb
@@ -36,7 +36,7 @@ module Upmark
 
       rule(:text) do
         match(/\A[\s\n\t ]+\Z/m).absent? >> # ignore entirely empty strings
-        match(/[^<>]/).repeat(1)
+        match(/[^<]/).repeat(1)
       end
 
       rule(:start_tag) do


### PR DESCRIPTION
EG every browser supports html like
```
Upmark.convert <<-HTML
  <div>
    Foo => bar
  </div>
HTML
```

Nokogiri::HTML5 will even generate such HTML without escaping the `>`.