### PR TITLE
Ignore base64 encoded data URLs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 2.0.0 / 2025-09-02
+
+* Potentially Breaking Change: `img` tags with base64 encoded `src` values,
+  which are not widely supported by markdown renderers, are removed to avoid
+  parser performance issues and crashes
+
 ## 1.1.0 / 2024-04-19
 * basic handling for nested lists
 

--- a/lib/upmark.rb
+++ b/lib/upmark.rb
@@ -14,7 +14,11 @@ module Upmark
     preprocess   = Transform::Preprocess.new
     markdown     = Transform::Markdown.new
 
-    ast = xml.parse(html.strip)
+    # Remove base64 data URLs that cause parser issues
+    html = html.gsub(/(data:image\/[^;]*;base64,)[A-Za-z0-9+\/=]+/, '').strip
+
+    ast = xml.parse(html)
+
     ast = normalise.apply(ast)
     ast = preprocess.apply(ast)
     ast = markdown.apply(ast)

--- a/lib/upmark/transform/markdown.rb
+++ b/lib/upmark/transform/markdown.rb
@@ -71,7 +71,7 @@ module Upmark
 
       element(:img) do |element|
         attributes = map_attributes_subtree(element[:attributes])
-        href       = attributes[:src]
+        href       = attributes[:src].to_s
         title      = attributes[:title]
         alt_text   = attributes[:alt]
 

--- a/spec/acceptance/upmark_spec.rb
+++ b/spec/acceptance/upmark_spec.rb
@@ -86,6 +86,17 @@ Labor MP calls to end dogs
 ![messenger bag skateboard](http://helvetica.com/image.gif "art party organic")
       MD
     end
+
+    specify "removes base64 data URLs" do
+      expect(<<~HTML).to convert_to("")
+        <img src="data:image/png;base64,abc" />
+      HTML
+
+      src = "abc" * 10000
+      expect(<<~HTML).to convert_to("")
+        <img src="data:image/png;base64,#{src}" />
+      HTML
+    end
   end
 
   context "<p>" do


### PR DESCRIPTION
This removes base64 encoded `src` values from `img` tags, which are not widely supported by markdown renderers, are are causing parser performance issues and crashes.
